### PR TITLE
adding support for sqlite3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default Bookshelf => {
     }
   });
 
-  if (client === 'sqlite' || client === 'sqlite'3) {
+  if (client === 'sqlite' || client === 'sqlite3') {
     const Collection = Bookshelf.Collection.prototype;
 
     Bookshelf.Collection = Bookshelf.Collection.extend({

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default Bookshelf => {
       // Parse JSON columns after model is saved.
       this.on('saved', parse.bind(this));
 
-      if (client === 'sqlite') {
+      if (client === 'sqlite' || client === 'sqlite3') {
         // Parse JSON columns after model is fetched.
         this.on('fetched', parse.bind(this));
       }
@@ -52,7 +52,7 @@ export default Bookshelf => {
     }
   });
 
-  if (client === 'sqlite') {
+  if (client === 'sqlite' || client === 'sqlite'3) {
     const Collection = Bookshelf.Collection.prototype;
 
     Bookshelf.Collection = Bookshelf.Collection.extend({


### PR DESCRIPTION
I've been using bookshelf-json-columns and started to use sqlite in memory DB's in my tests. Unfortunately, I ran into  some issues as I am using sqlite3 module and not sqlite, so I submit this pull request to add sqlite3