### PR TITLE
Add support for update with patch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bookshelf.Model.extend({
 });
 ```
 
-**NOTE:** This plugin extends the `initialize` method of Bookshelf's `Model`, so if you are also extending or overriding it on your models make sure to call its prototype after your work is done:
+**NOTE:** This plugin extends the `initialize` and `save` methods of Bookshelf's `Model`, so if you are also extending or overriding them on your models make sure to call their prototype after your work is done:
 
 ```js
 bookshelf.Model.extend({
@@ -42,10 +42,17 @@ bookshelf.Model.extend({
     // Do some stuff.
     store.addModel(this);
 
-    // Call the initialize prototype method.
+    // Call the `initialize` prototype method.
     bookshelf.Model.prototype.initialize.apply(this, arguments);
   },
   jsonColumns: ['foo'],
+  save: function() {
+    // Do some stuff.
+    store.validateModel(this);
+
+    // Call the `save` prototype method.
+    bookshelf.Model.prototype.save.apply(this, arguments);
+  },
   tableName: 'bar'
 });
 ```

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -93,7 +93,13 @@ describe('with PostgreSQL client', () => {
       model.get('foo').should.eql(['bar']);
     });
 
-    it('should keep a json value creating through a collection', async () => {
+    it('should keep the json value using save with a key and value', async () => {
+      const model = await Model.forge().save('foo', ['bar'], { method: 'insert' });
+
+      model.get('foo').should.eql(['bar']);
+    });
+
+    it('should keep a json value when creating through a collection', async () => {
       const Collection = repository.Collection.extend({ model: Model });
       const collection = Collection.forge();
 
@@ -122,6 +128,14 @@ describe('with PostgreSQL client', () => {
       await model.save();
 
       should(model.get('foo')).be.undefined();
+    });
+
+    it('should keep a json value when updating with `patch` option', async () => {
+      const model = await Model.forge().save();
+
+      await model.save({ foo: ['bar'] }, { patch: true });
+
+      model.get('foo').should.eql(['bar']);
     });
 
     it('should keep a json value when updating other columns', async () => {

--- a/test/sqlite/index.js
+++ b/test/sqlite/index.js
@@ -41,7 +41,7 @@ describe('with SQLite client', () => {
       const model = await Model.forge().save({ foo: ['bar'] });
       const fetched = await Model.forge({ id: model.get('id') }).fetch();
 
-      should(fetched.get('foo')).be.null()
+      should(fetched.get('foo')).be.null();
     });
 
     it('should not save a valid JSON value creating through a collection', async () => {
@@ -62,7 +62,7 @@ describe('with SQLite client', () => {
 
       const fetched = await Model.forge({ id: model.get('id') }).fetch();
 
-      should(fetched.get('foo')).be.null()
+      should(fetched.get('foo')).be.null();
     });
 
     it('should not override model prototype initialize method', async () => {
@@ -98,7 +98,13 @@ describe('with SQLite client', () => {
       fetched.get('foo').should.eql(['bar']);
     });
 
-    it('should keep a json value creating through a collection', async () => {
+    it('should keep the json value using save with a key and value', async () => {
+      const model = await Model.forge().save('foo', ['bar'], { method: 'insert' });
+
+      model.get('foo').should.eql(['bar']);
+    });
+
+    it('should keep a json value when creating through a collection', async () => {
       const Collection = repository.Collection.extend({ model: Model });
       const collection = Collection.forge();
 
@@ -134,6 +140,14 @@ describe('with SQLite client', () => {
       const fetched = await Model.forge({ id: model.get('id') }).fetch();
 
       should(fetched.get('foo')).be.null();
+    });
+
+    it('should keep a json value when updating with `patch` option', async () => {
+      const model = await Model.forge().save();
+
+      await model.save({ foo: ['bar'] }, { patch: true });
+
+      model.get('foo').should.eql(['bar']);
     });
 
     it('should keep a json value when updating other columns', async () => {


### PR DESCRIPTION
This PR adds support for update queries with the `patch` option, overriding the `save` method to stringify all given attributes registered as JSON columns and parse them after the primitive `save` is called.

Closes #25 