### PR TITLE
Add babel-plugin-array-includes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "stage-2"],
+  "plugins": ["add-module-exports", "array-includes", "transform-runtime"]
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "options": {
     "isparta": "--dir test/coverage",
-    "mocha": "--compilers js:babel/register --bail test"
+    "mocha": "--compilers js:babel-register --bail test"
   },
   "scripts": {
     "build": "rm -rf dist/* && ./node_modules/.bin/babel src/ --out-dir dist/",
@@ -35,19 +35,28 @@
     "lint": "git diff --cached --name-only --diff-filter=ACMRTUXB | grep -E '\\.(js)(\\..+)?$' | xargs eslint",
     "test": "mocha $npm_package_options_mocha"
   },
+  "dependencies": {
+    "babel-runtime": "6.11.6"
+  },
   "peerDependencies": {
     "bookshelf": ">= 0.7"
   },
   "devDependencies": {
-    "babel": "5.6.14",
+    "babel-cli": "6.14.0",
     "babel-eslint": "6.0.3",
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-array-includes": "2.0.3",
+    "babel-plugin-transform-runtime": "6.12.0",
+    "babel-preset-es2015": "6.14.0",
+    "babel-preset-stage-2": "6.13.0",
+    "babel-register": "6.14.0",
     "bookshelf": "0.9.1",
     "coveralls": "2.11.9",
     "eslint": "2.8.0",
     "eslint-config-seegno": "4.0.0",
     "eslint-plugin-babel": "3.2.0",
     "eslint-plugin-sort-class-members": "1.0.1",
-    "isparta": "3.5.3",
+    "isparta": "4.0.0",
     "knex": "0.9.0",
     "mocha": "2.2.5",
     "pg": "4.4.3",


### PR DESCRIPTION
This PR upgrades **babel** version to 6, adding some required plugins and presets as well as **babel-plugin-array-includes** to fix #28.