### PR TITLE
Fix stringifying null values with patch option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ export default Bookshelf => {
 
       // Stringify JSON columns.
       Object.keys(attributes).forEach(attribute => {
-        if (this.jsonColumns.includes(attribute)) {
+        if (this.jsonColumns.includes(attribute) && attributes[attribute]) {
           attributes[attribute] = JSON.stringify(attributes[attribute]);
         }
       });

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -130,6 +130,19 @@ describe('with PostgreSQL client', () => {
       should(model.get('foo')).be.undefined();
     });
 
+    it('should not stringify null values on update with `patch` option', async () => {
+      sinon.spy(ModelPrototype, 'save');
+
+      const model = await Model.forge().save();
+
+      await model.save({ foo: null }, { patch: true });
+
+      ModelPrototype.save.callCount.should.equal(2);
+      ModelPrototype.save.secondCall.args[0].should.eql({ foo: null });
+
+      sinon.restore(ModelPrototype);
+    });
+
     it('should keep a json value when updating with `patch` option', async () => {
       const model = await Model.forge().save();
 

--- a/test/sqlite/index.js
+++ b/test/sqlite/index.js
@@ -142,6 +142,19 @@ describe('with SQLite client', () => {
       should(fetched.get('foo')).be.null();
     });
 
+    it('should not stringify null values on update with `patch` option', async () => {
+      sinon.spy(ModelPrototype, 'save');
+
+      const model = await Model.forge().save();
+
+      await model.save({ foo: null }, { patch: true });
+
+      ModelPrototype.save.callCount.should.equal(2);
+      ModelPrototype.save.secondCall.args[0].should.eql({ foo: null });
+
+      sinon.restore(ModelPrototype);
+    });
+
     it('should keep a json value when updating with `patch` option', async () => {
       const model = await Model.forge().save();
 


### PR DESCRIPTION
This PR adds a condition to prevent null values being stringified with `patch` option.

Closes #31 