### PR TITLE
Update jsonColumns option to be a class property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,29 @@ var jsonColumns = require('bookshelf-json-columns');
 bookshelf.plugin(jsonColumns);
 ```
 
-Define which columns have JSON format with the `jsonColumns` prototype property:
+Define which columns have JSON format with the `jsonColumns` class property:
 
 ```js
 bookshelf.Model.extend({
-  jsonColumns: ['foo', 'bar'],
-  tableName: 'biz'
+  tableName: 'foo'
+}, {
+  jsonColumns: ['bar', 'biz']
 });
 ```
 
-**NOTE:** This plugin extends the `initialize` and `save` methods of Bookshelf's `Model`, so if you are also extending or overriding them on your models make sure to call their prototype after your work is done:
+If you're using ES6 class syntax, define `jsonColumns` as static property:
+
+```js
+class Model extends bookshelf.Model {
+  get tableName() {
+    return 'foo';
+  }
+
+  static jsonColumns = ['bar', 'biz'];
+}
+```
+
+This plugin extends the `initialize` and `save` methods of Bookshelf's `Model`, so if you are also extending or overriding them on your models make sure to call their prototype after your work is done:
 
 ```js
 bookshelf.Model.extend({
@@ -45,7 +58,6 @@ bookshelf.Model.extend({
     // Call the `initialize` prototype method.
     bookshelf.Model.prototype.initialize.apply(this, arguments);
   },
-  jsonColumns: ['foo'],
   save: function() {
     // Do some stuff.
     store.validateModel(this);
@@ -53,7 +65,9 @@ bookshelf.Model.extend({
     // Call the `save` prototype method.
     bookshelf.Model.prototype.save.apply(this, arguments);
   },
-  tableName: 'bar'
+  tableName: 'foo'
+}, {
+  jsonColumns: ['bar', 'biz']
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ function stringify(model, attributes, options) {
     return;
   }
 
-  this.jsonColumns.forEach(column => {
+  this.constructor.jsonColumns.forEach(column => {
     if (this.attributes[column]) {
       this.attributes[column] = JSON.stringify(this.attributes[column]);
     }
@@ -26,7 +26,7 @@ function parse(model, response, options) {
     return;
   }
 
-  this.jsonColumns.forEach(column => {
+  this.constructor.jsonColumns.forEach(column => {
     if (this.attributes[column]) {
       this.attributes[column] = JSON.parse(this.attributes[column]);
     }
@@ -43,7 +43,7 @@ export default Bookshelf => {
 
   Bookshelf.Model = Bookshelf.Model.extend({
     initialize() {
-      if (!this.jsonColumns) {
+      if (!this.constructor.jsonColumns) {
         return Model.initialize.apply(this, arguments);
       }
 
@@ -61,7 +61,7 @@ export default Bookshelf => {
       return Model.initialize.apply(this, arguments);
     },
     save(key, value, options) {
-      if (!this.jsonColumns) {
+      if (!this.constructor.jsonColumns) {
         return Model.save.apply(this, arguments);
       }
 
@@ -83,7 +83,7 @@ export default Bookshelf => {
 
       // Stringify JSON columns.
       Object.keys(attributes).forEach(attribute => {
-        if (this.jsonColumns.includes(attribute) && attributes[attribute]) {
+        if (this.constructor.jsonColumns.includes(attribute) && attributes[attribute]) {
           attributes[attribute] = JSON.stringify(attributes[attribute]);
         }
       });
@@ -92,7 +92,7 @@ export default Bookshelf => {
         .then(model => {
           // Parse JSON columns.
           Object.keys(attributes).forEach(attribute => {
-            if (this.jsonColumns.includes(attribute)) {
+            if (this.constructor.jsonColumns.includes(attribute)) {
               model.attributes[attribute] = JSON.parse(model.attributes[attribute]);
             }
           });
@@ -107,7 +107,7 @@ export default Bookshelf => {
 
     Bookshelf.Collection = Bookshelf.Collection.extend({
       initialize() {
-        if (!this.model.prototype.jsonColumns) {
+        if (!this.model.jsonColumns) {
           return Collection.initialize.apply(this, arguments);
         }
 

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -85,7 +85,7 @@ describe('with PostgreSQL client', () => {
   });
 
   describe('when a json column is registered', () => {
-    const Model = repository.Model.extend({ jsonColumns: ['foo'], tableName: 'test' });
+    const Model = repository.Model.extend({ tableName: 'test' }, { jsonColumns: ['foo'] });
 
     it('should keep the json value on create', async () => {
       const model = await Model.forge().save({ foo: ['bar'] });

--- a/test/sqlite/index.js
+++ b/test/sqlite/index.js
@@ -89,7 +89,7 @@ describe('with SQLite client', () => {
   });
 
   describe('when a json column is registered', () => {
-    const Model = repository.Model.extend({ jsonColumns: ['foo'], tableName: 'test' });
+    const Model = repository.Model.extend({ tableName: 'test' }, { jsonColumns: ['foo'] });
 
     it('should keep a json value on create', async () => {
       const model = await Model.forge().save({ foo: ['bar'] });


### PR DESCRIPTION
This updates the `jsonColumns` option to be a class property instead of prototype property, since such option should not be part of model instances properties. 

It also adds documentation for the plugin usage with class syntax.