### PR TITLE
Update dependencies versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-  "presets": ["es2015", "stage-2"],
-  "plugins": ["add-module-exports", "array-includes", "transform-runtime"]
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  },
+  "presets": ["es2015-node", "stage-3"],
+  "plugins": ["add-module-exports", "array-includes"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.nyc_output
 /node_modules
 /test.sqlite3
 /test/coverage

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,9 @@
+{
+  "instrument": false,
+  "report-dir": "test/coverage",
+  "reporter": [
+    "html",
+    "text-summary"
+  ],
+  "sourceMap": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_script:
   - psql -U postgres -c 'create database "bookshelf-json-columns";'
 
 node_js:
-  - "0.10"
   - "4"
   - "5"
   - "6"

--- a/package.json
+++ b/package.json
@@ -24,47 +24,42 @@
     "columns"
   ],
   "options": {
-    "isparta": "--dir test/coverage",
     "mocha": "--compilers js:babel-register --bail test"
   },
   "scripts": {
     "build": "rm -rf dist/* && ./node_modules/.bin/babel src/ --out-dir dist/",
     "changelog": "github_changelog_generator --bug-labels --enhancement-labels --header-label='# Changelog'",
     "coveralls": "npm run cover && cat ./test/coverage/lcov.info | coveralls",
-    "cover": "babel-node node_modules/isparta/bin/isparta cover $npm_package_options_isparta _mocha -- $npm_package_options_mocha",
+    "cover": "NODE_ENV=test nyc mocha $npm_package_options_mocha",
     "lint": "git diff --cached --name-only --diff-filter=ACMRTUXB | grep -E '\\.(js)(\\..+)?$' | xargs eslint",
     "test": "mocha $npm_package_options_mocha"
-  },
-  "dependencies": {
-    "babel-runtime": "6.11.6"
   },
   "peerDependencies": {
     "bookshelf": ">= 0.7"
   },
   "devDependencies": {
-    "babel-cli": "6.14.0",
+    "babel-cli": "6.18.0",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-array-includes": "2.0.3",
-    "babel-plugin-transform-runtime": "6.12.0",
-    "babel-preset-es2015": "6.14.0",
-    "babel-preset-stage-2": "6.13.0",
-    "babel-register": "6.14.0",
-    "bookshelf": "0.9.1",
-    "coveralls": "2.11.9",
-    "eslint": "3.4.0",
-    "eslint-config-seegno": "6.0.0",
-    "isparta": "4.0.0",
-    "knex": "0.9.0",
-    "mocha": "2.2.5",
-    "pg": "4.4.3",
-    "pre-commit": "1.1.2",
-    "should": "7.1.1",
-    "sinon": "1.17.2",
-    "sqlite3": "3.1.6"
+    "babel-plugin-istanbul": "2.0.3",
+    "babel-preset-es2015-node": "4.0.2",
+    "babel-preset-stage-3": "6.17.0",
+    "babel-register": "6.18.0",
+    "bookshelf": "0.10.2",
+    "coveralls": "2.11.14",
+    "eslint": "3.8.1",
+    "eslint-config-seegno": "8.0.0",
+    "knex": "0.12.6",
+    "mocha": "3.1.2",
+    "nyc": "8.3.2",
+    "pg": "6.1.0",
+    "pre-commit": "1.1.3",
+    "should": "11.1.1",
+    "sinon": "1.17.6",
+    "sqlite3": "3.1.7"
   },
   "engines": {
-    "iojs": ">= 1.0.0",
-    "node": ">= 0.10"
+    "node": ">= 4"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
This PR updates all dependencies versions, and also:

* Replace *isparta* with *nyc*;
* Update `cover` and `coveralls` script to use *nyc*;
* Update **babel** plugins;
* Update **babel** configuration;
* Remove support below Node.js 4;