### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+/.babelrc
+/.eslintrc.yml
+/.travis.yml
+/src
+/test
+/test.sqlite3


### PR DESCRIPTION
This PR adds `.npmignore` file to the project, excluding unnecessary files and folders from npm publishing.