### PR TITLE
Add .nycrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 /.babelrc
 /.eslintrc.yml
+/.nycrc
 /.travis.yml
 /src
 /test


### PR DESCRIPTION
This PR adds *.nycrc* to *.npmignore*.