### PR TITLE
Fix parsing on saving through query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ function stringify(model, attributes, options) {
     return;
   }
 
+  // Mark json columns as stringfied.
+  options.parseJsonColumns = true;
+
   this.constructor.jsonColumns.forEach(column => {
     if (this.attributes[column]) {
       this.attributes[column] = JSON.stringify(this.attributes[column]);
@@ -20,9 +23,15 @@ function stringify(model, attributes, options) {
  * Parse JSON columns.
  */
 
-function parse(model, response, options) {
+function parse(model, response, options = {}) {
   // Do not parse with `patch` option.
-  if (options && options.patch) {
+  if (options.patch) {
+    return;
+  }
+
+  // Do not parse on `fetched` event after saving.
+  // eslint-disable-next-line no-underscore-dangle
+  if (!options.parseJsonColumns && options.query && options.query._method !== 'select') {
     return;
   }
 

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -3,13 +3,13 @@
  * Module dependencies.
  */
 
+import { dropTable, recreateTable } from '../utils';
 import bookshelf from 'bookshelf';
 import jsonColumns from '../../src';
 import knex from 'knex';
 import knexfile from './knexfile';
 import should from 'should';
 import sinon from 'sinon';
-import { dropTable, recreateTable } from '../utils';
 
 /**
  * Test `bookshelf-json-columns` plugin with PostgreSQL client.
@@ -29,7 +29,7 @@ describe('with PostgreSQL client', () => {
     await dropTable(repository);
   });
 
-  describe('when a json column is not registered', () => {
+  describe('when a JSON column is not registered', () => {
     const Model = repository.Model.extend({ tableName: 'test' });
 
     it('should throw an error on create', async () => {
@@ -84,22 +84,22 @@ describe('with PostgreSQL client', () => {
     });
   });
 
-  describe('when a json column is registered', () => {
+  describe('when a JSON column is registered', () => {
     const Model = repository.Model.extend({ tableName: 'test' }, { jsonColumns: ['foo'] });
 
-    it('should keep the json value on create', async () => {
+    it('should keep the JSON value on create', async () => {
       const model = await Model.forge().save({ foo: ['bar'] });
 
       model.get('foo').should.eql(['bar']);
     });
 
-    it('should keep the json value using save with a key and value', async () => {
+    it('should keep the JSON value using save with a key and value', async () => {
       const model = await Model.forge().save('foo', ['bar'], { method: 'insert' });
 
       model.get('foo').should.eql(['bar']);
     });
 
-    it('should keep a json value when creating through a collection', async () => {
+    it('should keep a JSON value when creating through a collection', async () => {
       const Collection = repository.Collection.extend({ model: Model });
       const collection = Collection.forge();
 
@@ -114,7 +114,7 @@ describe('with PostgreSQL client', () => {
       should(model.get('foo')).be.undefined();
     });
 
-    it('should keep a json value on update', async () => {
+    it('should keep a JSON value on update', async () => {
       const model = await Model.forge().save();
 
       await model.save({ foo: ['bar'] });
@@ -143,7 +143,7 @@ describe('with PostgreSQL client', () => {
       sinon.restore(ModelPrototype);
     });
 
-    it('should keep a json value when updating with `patch` option', async () => {
+    it('should keep a JSON value when updating with `patch` option', async () => {
       const model = await Model.forge().save();
 
       await model.save({ foo: ['bar'] }, { patch: true });
@@ -151,7 +151,7 @@ describe('with PostgreSQL client', () => {
       model.get('foo').should.eql(['bar']);
     });
 
-    it('should keep a json value when updating other columns', async () => {
+    it('should keep a JSON value when updating other columns', async () => {
       const model = await Model.forge().save({ foo: ['bar'] });
 
       await model.save({ qux: 'qix' }, { patch: true });
@@ -159,10 +159,20 @@ describe('with PostgreSQL client', () => {
       model.get('foo').should.eql(['bar']);
     });
 
-    it('should keep a json value on fetch', async () => {
+    it('should keep a JSON value on fetch', async () => {
       await Model.forge().save({ foo: ['bar'], qux: 'qix' });
 
       const model = await Model.forge({ qux: 'qix' }).fetch();
+
+      model.get('foo').should.eql(['bar']);
+    });
+
+    it('should keep a JSON value when updating through query', async () => {
+      const model = await Model.forge().save({ foo: ['bar'] });
+
+      model.query().update({ qux: 'qix' });
+
+      await model.refresh();
 
       model.get('foo').should.eql(['bar']);
     });


### PR DESCRIPTION
This PR fixes parsing of columns when a `fetched` event is triggered after inserting or updating through knex query builder.

Closes #42 