### PR TITLE
Add user to postgres knexfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
 
 after_success:
   - npm run coveralls

--- a/test/postgres/knexfile.js.dist
+++ b/test/postgres/knexfile.js.dist
@@ -8,6 +8,7 @@ export default {
   connection: {
     charset: 'utf8',
     database: 'bookshelf-json-columns',
-    host: 'localhost'
+    host: 'localhost',
+    user: 'postgres'
   }
 };


### PR DESCRIPTION
This PR adds the user `postgres` to the PostgreSQL knexfile which is causing any build to fail. It also adds Node.js 7 to *.travis.yml*.