### PR TITLE
Add lcov reporter to .nycrc

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,6 +3,7 @@
   "report-dir": "test/coverage",
   "reporter": [
     "html",
+    "lcov",
     "text-summary"
   ],
   "sourceMap": false


### PR DESCRIPTION
This PR adds the `lcov` reporter to `.nycrc`.

The generated `lcov.info` file is needed for coveralls to properly work. 