### PR TITLE
Stringify on save for MySQL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,6 @@ function parse(model, response, options = {}) {
 export default Bookshelf => {
   const Model = Bookshelf.Model.prototype;
   const client = Bookshelf.knex.client.config.client;
-  const handleOnSaving = client !== 'mysql';
   const parseOnFetch = client === 'sqlite' || client === 'sqlite3' || client === 'mysql';
 
   Bookshelf.Model = Bookshelf.Model.extend({
@@ -58,13 +57,11 @@ export default Bookshelf => {
         return Model.initialize.apply(this, arguments);
       }
 
-      if (handleOnSaving) {
-        // Stringify JSON columns before model is saved.
-        this.on('saving', stringify.bind(this));
+      // Stringify JSON columns before model is saved.
+      this.on('saving', stringify.bind(this));
 
-        // Parse JSON columns after model is saved.
-        this.on('saved', parse.bind(this));
-      }
+      // Parse JSON columns after model is saved.
+      this.on('saved', parse.bind(this));
 
       if (parseOnFetch) {
         // Parse JSON columns after model is fetched.

--- a/test/mysql/index.js
+++ b/test/mysql/index.js
@@ -32,33 +32,77 @@ describe('with MySQL client', () => {
   describe('when a JSON column is not registered', () => {
     const Model = repository.Model.extend({ tableName: 'test' });
 
-    it('should not parse a JSON value on fetch', async () => {
-      const model = await Model.forge().save({ foo: JSON.stringify(['bar']) });
+    it('should throw an error on create', async () => {
+      try {
+        await Model.forge().save({ foo: { bar: 'baz' } });
 
-      await model.refresh();
-
-      model.get('foo').should.equal(JSON.stringify(['bar']));
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Error);
+        e.code.should.equal('ER_BAD_FIELD_ERROR');
+      }
     });
 
-    it('should keep a JSON value on create', async () => {
-      const model = await Model.forge().save({ foo: ['bar'] });
+    it('should throw an error creating through a collection', async () => {
+      const Collection = repository.Collection.extend({ model: Model });
+      const collection = Collection.forge();
 
-      model.get('foo').should.eql(['bar']);
+      try {
+        await collection.create(Model.forge({ foo: { bar: 'baz' } }));
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Error);
+        e.code.should.equal('ER_BAD_FIELD_ERROR');
+      }
     });
 
-    it('should keep a JSON value using save with a key and value', async () => {
-      const model = await Model.forge().save('foo', ['bar'], { method: 'insert' });
+    it('should throw an error on update', async () => {
+      const model = await Model.forge().save();
 
-      model.get('foo').should.eql(['bar']);
+      try {
+        await model.save({ foo: { bar: 'baz' } });
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Error);
+        e.code.should.equal('ER_BAD_FIELD_ERROR');
+      }
+    });
+
+    it('should not override model prototype initialize method', async () => {
+      sinon.spy(ModelPrototype, 'initialize');
+
+      Model.forge();
+
+      ModelPrototype.initialize.callCount.should.equal(1);
+
+      sinon.restore(ModelPrototype);
+    });
+  });
+
+  describe('when a JSON column is registered', () => {
+    const Model = repository.Model.extend({ tableName: 'test' }, { jsonColumns: ['foo'] });
+
+    it('should keep the JSON value on create', async () => {
+      const model = await Model.forge().save({ foo: { bar: 'baz' } });
+
+      model.get('foo').should.eql({ bar: 'baz' });
+    });
+
+    it('should keep the JSON value using save with a key and value', async () => {
+      const model = await Model.forge().save('foo', { bar: 'baz' }, { method: 'insert' });
+
+      model.get('foo').should.eql({ bar: 'baz' });
     });
 
     it('should keep a JSON value when creating through a collection', async () => {
       const Collection = repository.Collection.extend({ model: Model });
       const collection = Collection.forge();
 
-      await collection.create(Model.forge({ foo: ['bar'] }));
+      await collection.create(Model.forge({ foo: { bar: 'baz' } }));
 
-      collection.at(0).get('foo').should.eql(['bar']);
+      collection.at(0).get('foo').should.eql({ bar: 'baz' });
     });
 
     it('should keep a null value on create', async () => {
@@ -70,9 +114,9 @@ describe('with MySQL client', () => {
     it('should keep a JSON value on update', async () => {
       const model = await Model.forge().save();
 
-      await model.save({ foo: ['bar'] });
+      await model.save({ foo: { bar: 'baz' } });
 
-      model.get('foo').should.eql(['bar']);
+      model.get('foo').should.eql({ bar: 'baz' });
     });
 
     it('should keep a null value on update', async () => {
@@ -99,49 +143,35 @@ describe('with MySQL client', () => {
     it('should keep a JSON value when updating with `patch` option', async () => {
       const model = await Model.forge().save();
 
-      await model.save({ foo: ['bar'] }, { patch: true });
+      await model.save({ foo: { bar: 'baz' } }, { patch: true });
 
-      model.get('foo').should.eql(['bar']);
+      model.get('foo').should.eql({ bar: 'baz' });
     });
 
     it('should keep a JSON value when updating other columns', async () => {
-      const model = await Model.forge().save({ foo: ['bar'] });
+      const model = await Model.forge().save({ foo: { bar: 'baz' } });
 
       await model.save({ qux: 'qix' }, { patch: true });
 
-      model.get('foo').should.eql(['bar']);
+      model.get('foo').should.eql({ bar: 'baz' });
+    });
+
+    it('should keep a JSON value on fetch', async () => {
+      await Model.forge().save({ foo: { bar: 'baz' }, qux: 'qix' });
+
+      const model = await Model.forge({ qux: 'qix' }).fetch();
+
+      model.get('foo').should.eql({ bar: 'baz' });
     });
 
     it('should keep a JSON value when updating through query', async () => {
-      const model = await Model.forge().save({ foo: ['bar'] });
+      const model = await Model.forge().save({ foo: { bar: 'baz' } });
 
       model.query().update({ qux: 'qix' });
 
       await model.refresh();
 
-      model.get('foo').should.eql(['bar']);
-    });
-
-    it('should not override model prototype initialize method', async () => {
-      sinon.spy(ModelPrototype, 'initialize');
-
-      Model.forge();
-
-      ModelPrototype.initialize.callCount.should.equal(1);
-
-      sinon.restore(ModelPrototype);
-    });
-  });
-
-  describe('when a JSON column is registered', () => {
-    const Model = repository.Model.extend({ tableName: 'test' }, { jsonColumns: ['foo'] });
-
-    it('should keep a JSON value on fetch', async () => {
-      const model = await Model.forge().save({ foo: JSON.stringify(['bar']) });
-
-      await model.refresh();
-
-      model.get('foo').should.eql(['bar']);
+      model.get('foo').should.eql({ bar: 'baz' });
     });
 
     it('should not override model initialize method', async () => {


### PR DESCRIPTION
@ricardogama Heya.  I finally took the time to have a deeper look into this, and I think this should resolve what we were discussing before in #47.  Specifically, I've changed the MySQL support tests to demonstrate failure without use of the plugin and proper functionality with use of it.  I saw the difficulty you were referring to with regards to reproducing the problem.  It seems as though MySQL accepts arrays on save but not objects.